### PR TITLE
Catch removeRipple exception

### DIFF
--- a/portify.js
+++ b/portify.js
@@ -910,7 +910,9 @@ function clearwaves(){ // Clear ripple animations, they build up if we dont.
 	if (x !== undefined){
 		rl = x.ripples.length;
 		for (var i = 0; i < rl; i++) {
-			x.removeRipple(x.ripples[0]);
+			try {
+				x.removeRipple(x.ripples[0]);
+			} catch {}
 		}
 	}
 }


### PR DESCRIPTION
```removeRipple``` does not always exist on object and an exception when calling the function is not caught by GPM.
Catching the exception allows normal functionality to continue.